### PR TITLE
add jwks_uri to issuer option

### DIFF
--- a/src/core/lib/oauth/client.ts
+++ b/src/core/lib/oauth/client.ts
@@ -12,9 +12,9 @@ export async function openidClient(
   options: InternalOptions<"oauth">
 ): Promise<Client> {
   const provider = options.provider
-  
+
   if (provider.httpOptions) custom.setHttpOptionsDefaults(provider.httpOptions)
-  
+
   let issuer: Issuer
   if (provider.wellKnown) {
     issuer = await Issuer.discover(provider.wellKnown)
@@ -28,6 +28,7 @@ export async function openidClient(
       token_endpoint: provider.token?.url ?? provider.token,
       // @ts-expect-error
       userinfo_endpoint: provider.userinfo?.url ?? provider.userinfo,
+      jwks_uri: provider.jwksUri as string,
     })
   }
 

--- a/src/core/lib/oauth/client.ts
+++ b/src/core/lib/oauth/client.ts
@@ -28,7 +28,7 @@ export async function openidClient(
       token_endpoint: provider.token?.url ?? provider.token,
       // @ts-expect-error
       userinfo_endpoint: provider.userinfo?.url ?? provider.userinfo,
-      jwks_uri: provider.jwksUri as string,
+      jwks_uri: provider.jwksUri,
     })
   }
 

--- a/src/providers/oauth.ts
+++ b/src/providers/oauth.ts
@@ -145,6 +145,7 @@ export interface OAuthConfig<P> extends CommonProviderOptions, PartialIssuer {
   requestTokenUrl?: string
   profileUrl?: string
   encoding?: string
+  jwksUri?: string
 }
 
 export type OAuthUserConfig<P> = Omit<


### PR DESCRIPTION
* I wanted to customize authorization_endpoint.
  - to use customized authorization_endpoint, `wellKnown` parameter of OAuthConfig must be blank and `jwks_uri` must be given.
* This pull request adds `jwksUri` as OAuthConfig parameter and uses it in `openid-client`'s Issuer constructor.
* About `jwks_uri`, see: https://openid.net/specs/openid-connect-discovery-1_0.html#ProviderMetadata
* Example of Google's OpenID Connect wellKnown metadata
  - https://accounts.google.com/.well-known/openid-configuration